### PR TITLE
agent-serve-fixes

### DIFF
--- a/internal/agent.go
+++ b/internal/agent.go
@@ -26,11 +26,12 @@ func handleAgentDispatch(client serve.Client) cli.ActionFunc {
 			return errors.New("url is required")
 		}
 
-		_, err := client.DispatchAgent(c.Context, urlArg)
+		result, err := client.DispatchAgent(c.Context, urlArg)
 		if err != nil {
 			return err
 		}
 
+		fmt.Fprintf(c.App.Writer, "Dispatched %d comments to agent\n", len(result.Comments))
 		return nil
 	}
 }

--- a/internal/agent.go
+++ b/internal/agent.go
@@ -10,13 +10,17 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func handleAgentDispatch(client serve.Client) cli.ActionFunc {
+func serveBeforeFunc(client serve.Client) cli.BeforeFunc {
 	return func(c *cli.Context) error {
-
 		if !client.IsServerRunning(c.Context) {
 			return errors.New("dev-cli server not running start with: dev serve")
 		}
+		return nil
+	}
+}
 
+func handleAgentDispatch(client serve.Client) cli.ActionFunc {
+	return func(c *cli.Context) error {
 		urlArg := c.Args().First()
 		if urlArg == "" {
 			return errors.New("url is required")
@@ -33,10 +37,6 @@ func handleAgentDispatch(client serve.Client) cli.ActionFunc {
 
 func handleAgentAttach(client serve.Client) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		if !client.IsServerRunning(c.Context) {
-			return errors.New("dev-cli server not running start with: dev serve")
-		}
-
 		urlArg := c.String("url")
 		opencodeURL := urlArg
 

--- a/internal/agent.go
+++ b/internal/agent.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
 
 	"github.com/thomasgormley/dev-cli-go/internal/serve"
 	"github.com/urfave/cli/v2"
@@ -25,5 +28,34 @@ func handleAgentDispatch(client serve.Client) cli.ActionFunc {
 		}
 
 		return nil
+	}
+}
+
+func handleAgentAttach(client serve.Client) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		if !client.IsServerRunning(c.Context) {
+			return errors.New("dev-cli server not running start with: dev serve")
+		}
+
+		urlArg := c.String("url")
+		opencodeURL := urlArg
+
+		if opencodeURL == "" {
+			health, err := client.GetHealth(c.Context)
+			if err != nil {
+				return errors.New("failed to get health from server")
+			}
+			if !health.OpenCodeLive {
+				return errors.New("OpenCode server not running")
+			}
+			opencodeURL = health.OpenCodeURL
+		}
+
+		fmt.Fprintf(c.App.Writer, "Opening %s in browser...\n", opencodeURL)
+
+		browserCmd := exec.Command("open", opencodeURL)
+		browserCmd.Stdout = os.Stdout
+		browserCmd.Stderr = os.Stderr
+		return browserCmd.Run()
 	}
 }

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -75,7 +75,7 @@ func (r Repo) ResetHard(ref string) error {
 	return runGit(r.path, "reset", "--hard", ref)
 }
 
-func (r Repo) SyncToRemote(branch string) error {
+func (r Repo) SyncFromRemote(branch string) error {
 	if err := r.FetchBranch(branch); err != nil {
 		return err
 	}

--- a/internal/pr.go
+++ b/internal/pr.go
@@ -24,42 +24,35 @@ func handlePRCreate(stdout, stderr io.Writer, ghCli gh.GitHubClienter) cli.Actio
 			return err
 		}
 
-		// prStatus, err := ghCli.PRStatus("")
-		// if err != nil {
-		// 	// non critical error, just continue
-		// }
+		force := c.Bool("force")
+		var title, body string
+		var err error
 
-		// if !prStatus.CurrentBranch.Closed {
-		// 	print.Info(stdout,
-		// 		print.ColorNote(print.InfoSym),
-		// 		"Pull request already exists for this branch",
-		// 	)
-		// 	print.Info(stdout, print.WrapTop(
-		// 		print.ColorNote("Title:"),
-		// 		prStatus.CurrentBranch.Title,
-		// 	))
-		// 	print.Info(stdout, print.WrapBottom(
-		// 		print.ColorNote("URL:"),
-		// 		prStatus.CurrentBranch.URL,
-		// 	))
+		if force {
+			branch, err := git.CurrentBranch()
+			if err != nil {
+				return err
+			}
+			title = prTitleFromBranch(branch)
+			if title == "" {
+				title = branch
+			}
+			body, err = bodyOrPRTemplate(c)
+			if err != nil {
+				return err
+			}
+		} else {
+			title, err = titleOrPrompt(c)
+			if err != nil {
+				return err
+			}
 
-		// 	if err := promptForOpen(stdout, ghCli); err != nil {
-		// 		print.Warning(stdout, print.WarningSym, "Could not open PR in browser")
-		// 	}
-		// 	return cli.Exit("", 0)
-		// }
-
-		title, err := titleOrPrompt(c)
-		if err != nil {
-			return err
+			body, err = bodyOrPRTemplate(c)
+			if err != nil {
+				return err
+			}
 		}
 
-		body, err := bodyOrPRTemplate(c)
-		if err != nil {
-			return err
-		}
-
-		// Show info about what we're using
 		base := c.String("base")
 		draft := c.Bool("draft")
 		if body == "" {
@@ -80,8 +73,10 @@ func handlePRCreate(stdout, stderr io.Writer, ghCli gh.GitHubClienter) cli.Actio
 			return cli.Exit("", 1)
 		}
 
-		if err := promptForOpen(stdout, ghCli); err != nil {
-			return err
+		if !force {
+			if err := promptForOpen(stdout, ghCli); err != nil {
+				return err
+			}
 		}
 
 		return cli.Exit("", 0)

--- a/internal/run.go
+++ b/internal/run.go
@@ -220,6 +220,18 @@ func Run(
 						Args:        true,
 						Action:      handleAgentDispatch(serveClient),
 					},
+					{
+						Name:        "attach",
+						Usage:       "Open the dev agent web UI",
+						Description: "Opens the OpenCode web UI in the browser",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:  "url",
+								Usage: "URL of the OpenCode server (auto-detected from serve if not provided)",
+							},
+						},
+						Action: handleAgentAttach(serveClient),
+					},
 				},
 			},
 			{

--- a/internal/run.go
+++ b/internal/run.go
@@ -212,6 +212,7 @@ func Run(
 				Name:        "agent",
 				Usage:       "Dev agent operations",
 				Description: "Commands for interacting with the dev agent service",
+				Before:      serveBeforeFunc(serveClient),
 				Subcommands: []*cli.Command{
 					{
 						Name:        "dispatch",

--- a/internal/run.go
+++ b/internal/run.go
@@ -79,6 +79,11 @@ func Run(
 								Aliases: []string{"d"},
 								Value:   true,
 							},
+							&cli.BoolFlag{
+								Name:    "force",
+								Usage:   "skip prompts and use defaults",
+								Aliases: []string{"f"},
+							},
 						},
 					},
 					{

--- a/internal/serve.go
+++ b/internal/serve.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sst/opencode-sdk-go"
+	"github.com/sst/opencode-sdk-go/option"
 	"github.com/thomasgormley/dev-cli-go/internal/githubapi"
 	"github.com/thomasgormley/dev-cli-go/internal/serve"
 	"github.com/urfave/cli/v2"
@@ -39,12 +41,15 @@ func handleServe() cli.ActionFunc {
 			}
 		}
 
+		opencodeClient := opencode.NewClient(option.WithBaseURL(fmt.Sprintf("http://%s:%s", opencodeHost, opencodePort)))
+
 		srv := &http.Server{
 			Addr: net.JoinHostPort(host, port),
 			Handler: serve.Handle(c.Context, serve.HandleOpts{
 				GitHubUser:     os.Getenv("DEV_GITHUB_USER"),
-				GitHubClient:   ghClient,
+				GitHubClient:   *ghClient,
 				AllowedOrigins: []string{"http://" + host, "https://" + host},
+				OpenCodeClient: *opencodeClient,
 				OpenCode: serve.OpenCodeConfig{
 					Provider: provider,
 					Model:    model,

--- a/internal/serve/client.go
+++ b/internal/serve/client.go
@@ -68,36 +68,36 @@ func (c *Client) IsServerRunning(ctx context.Context) bool {
 	return resp.StatusCode == 200
 }
 
-func (c *Client) GetHealth(ctx context.Context) (*HealthResponse, error) {
+func (c Client) GetHealth(ctx context.Context) (HealthResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/api/health", nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return HealthResponse{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetching health: %w", err)
+		return HealthResponse{}, fmt.Errorf("fetching health: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading body: %w", err)
+		return HealthResponse{}, fmt.Errorf("reading body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("health check failed: %s", respBody)
+		return HealthResponse{}, fmt.Errorf("health check failed: %s", respBody)
 	}
 
 	var result HealthResponse
 	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("decoding response: %w", err)
+		return HealthResponse{}, fmt.Errorf("decoding response: %w", err)
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 func (c *Client) DispatchAgent(ctx context.Context, prURL string) (*AgentResponse, error) {

--- a/internal/serve/client.go
+++ b/internal/serve/client.go
@@ -27,6 +27,13 @@ type DispatchRequest struct {
 	URL string `json:"url"`
 }
 
+type HealthResponse struct {
+	Status         string `json:"status"`
+	OpenCodeLive   bool   `json:"opencodeLive"`
+	OpenCodeURL    string `json:"opencodeUrl"`
+	OpenCodeStatus string `json:"opencodeStatus"`
+}
+
 type Client struct {
 	baseURL string
 	http    *http.Client
@@ -59,6 +66,38 @@ func (c *Client) IsServerRunning(ctx context.Context) bool {
 	defer resp.Body.Close()
 
 	return resp.StatusCode == 200
+}
+
+func (c *Client) GetHealth(ctx context.Context) (*HealthResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/api/health", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching health: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("health check failed: %s", respBody)
+	}
+
+	var result HealthResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return &result, nil
 }
 
 func (c *Client) DispatchAgent(ctx context.Context, prURL string) (*AgentResponse, error) {

--- a/internal/serve/client.go
+++ b/internal/serve/client.go
@@ -124,7 +124,7 @@ func (c *Client) DispatchAgent(ctx context.Context, prURL string) (*AgentRespons
 		return nil, fmt.Errorf("reading body: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		return nil, fmt.Errorf("agent dispatch failed: %s", respBody)
 	}
 

--- a/internal/serve/handle_agent_dispatch.go
+++ b/internal/serve/handle_agent_dispatch.go
@@ -315,9 +315,13 @@ func buildPRSystemPrompt(prDetails PRDetails) string {
 	return fmt.Sprintf(`Instructions:
 - You are helping with a GitHub pull request
 - Read each comment and execute the requested task
-- Commit changes with clear, concise messages
-- Reply to comments with your changes and include session metadata
-- Use bash to make changes, then commit and push
+- Respond to the user's request with your changes and findings
+- Your response will be added as a comment to the PR automatically
+
+When making changes:
+- DO NOT commit or push - this will be handled automatically
+- Always run 'go build ./...' and 'go test ./...' to verify your changes work
+- If the task is too complex or tests keep failing, stop, undo the changes, and explain what you attempted, how far you got, and what the issue was
 
 PR Details:
 - PR #%d: %s

--- a/internal/serve/handle_agent_dispatch.go
+++ b/internal/serve/handle_agent_dispatch.go
@@ -1,0 +1,377 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/sst/opencode-sdk-go"
+
+	"github.com/thomasgormley/dev-cli-go/internal/git"
+	"github.com/thomasgormley/dev-cli-go/internal/githubapi"
+	"github.com/thomasgormley/dev-cli-go/internal/queuelib"
+)
+
+func handlerAgentDispatch(queue queuelib.Queue[agentDispatchJob], ghClient githubapi.Client, opencodeClient opencode.Client, user string, opencodeConfig OpenCodeConfig) http.Handler {
+	type request struct {
+		URL string `json:"url"`
+	}
+	type response struct {
+		SessionID string    `json:"sessionId"`
+		Comments  []Comment `json:"comments"`
+		RepoPath  string    `json:"repoPath"`
+		Status    string    `json:"status"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			encode(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+
+		req, err := decode[request](r)
+		if err != nil {
+			encode(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			return
+		}
+
+		if req.URL == "" {
+			encode(w, http.StatusBadRequest, map[string]string{"error": "url is required"})
+			return
+		}
+
+		prInfo, err := parseGitHubPRURL(req.URL)
+		if err != nil {
+			encode(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
+		log.Printf("PR: owner=%s repo=%s number=%d", prInfo.Owner, prInfo.Repo, prInfo.Number)
+
+		prDetails, err := fetchPRDetails(r.Context(), ghClient, prInfo)
+		if err != nil {
+			encode(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+
+		if prDetails.Author != user {
+			encode(w, http.StatusForbidden, map[string]string{"error": "PR author is not authorized"})
+			return
+		}
+
+		actionable := filterActionableComments(prDetails.Comments, user)
+
+		branch := prDetails.HeadBranch
+		repo, err := git.EnsureClone(r.Context(), prInfo.Owner, prInfo.Repo, branch)
+		if err != nil {
+			encode(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+
+		sessionID, err := createOpencodeSession(r.Context(), opencodeClient, repo.Path(), opencodeConfig)
+		if err != nil {
+			encode(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to create session: %v", err)})
+			return
+		}
+
+		enqueued := 0
+		for _, c := range actionable {
+			job := agentDispatchJob{
+				prInfo:     prInfo,
+				prDetails:  prDetails,
+				headBranch: prDetails.HeadBranch,
+				comment:    c,
+				repoPath:   repo.Path(),
+				sessionID:  sessionID,
+				user:       user,
+			}
+			if err := queue.Enqueue(r.Context(), job); err != nil {
+				log.Printf("failed to enqueue comment %d: %v", c.ID, err)
+				continue
+			}
+			enqueued++
+		}
+
+		status := "accepted"
+		if enqueued == 0 {
+			status = "no_actionable"
+		}
+		encode(w, http.StatusAccepted, response{SessionID: sessionID, Comments: actionable, RepoPath: repo.Path(), Status: status})
+	})
+}
+
+func processAgentDispatchQueue(ctx context.Context, queue queuelib.Queue[agentDispatchJob], ghClient githubapi.Client, opencodeClient opencode.Client, config OpenCodeConfig) {
+	for {
+		job, ok := queue.Dequeue(ctx)
+		if !ok {
+			return
+		}
+		if err := runAgentDispatchJob(ctx, ghClient, opencodeClient, config, job); err != nil {
+			log.Printf("job failed for comment %d: %v", job.comment.ID, err)
+		}
+	}
+}
+
+func runAgentDispatchJob(ctx context.Context, ghClient githubapi.Client, opencodeClient opencode.Client, config OpenCodeConfig, job agentDispatchJob) error {
+	var (
+		prInfo    = job.prInfo
+		prDetails = job.prDetails
+		repoPath  = job.repoPath
+		sessionID = job.sessionID
+		branch    = job.headBranch
+		c         = job.comment
+	)
+
+	if err := react(ctx, ghClient, c, prInfo); err != nil {
+		return fmt.Errorf("reacting: %w", err)
+	}
+
+	systemPrompt := buildPRSystemPrompt(prDetails)
+
+	promptText := prompt(c)
+	replyText, err := promptJob(ctx, opencodeClient, sessionID, promptText, systemPrompt, repoPath, config)
+	if err != nil {
+		return fmt.Errorf("prompting job: %w", err)
+	}
+
+	commitMsg, err := promptJob(ctx,
+		opencodeClient,
+		sessionID,
+		fmt.Sprintf("Summarize the following in less than 40 characters for the purposes of a commit message:\n\n%s", replyText),
+		systemPrompt,
+		repoPath,
+		config,
+	)
+	if err != nil {
+		commitMsg = "auto"
+	}
+
+	repo := git.Open(repoPath)
+	if err := commit(repo, branch, commitMsg); err != nil {
+		return fmt.Errorf("committing: %w", err)
+	}
+
+	if err := repo.SyncToRemote(branch); err != nil {
+		return fmt.Errorf("syncing: %w", err)
+	}
+
+	var commentURL string
+	if c.IsReviewComment() {
+		commentURL = fmt.Sprintf("https://github.com/%s/%s/pull/%d#discussion_r%d", prInfo.Owner, prInfo.Repo, prInfo.Number, c.ID)
+	} else {
+		commentURL = fmt.Sprintf("https://github.com/%s/%s/pull/%d#issuecomment-%d", prInfo.Owner, prInfo.Repo, prInfo.Number, c.ID)
+	}
+	metadata := fmt.Sprintf("<details><summary>info</summary>\n\n| Key | Value |\n|-----|-------|\n| In reply to | [#%d](%s) |\n| Session | `%s` |\n\n</details>", c.ID, commentURL, sessionID)
+	if err := comment(ctx, ghClient, c, prInfo, replyText+"\n\n"+metadata); err != nil {
+		return fmt.Errorf("commenting: %w", err)
+	}
+
+	log.Printf("comment %d processed successfully", c.ID)
+	return nil
+}
+
+func prompt(c Comment) string {
+	body := strings.TrimSpace(strings.TrimPrefix(c.Body, "@"+c.Author))
+
+	if !c.IsReviewComment() {
+		return body
+	}
+
+	commentContext := fmt.Sprintf("You are reviewing a comment on file \"%s\" at line %d.", c.FilePath, c.Line)
+	if c.DiffHunk != "" {
+		commentContext = fmt.Sprintf("You are reviewing a comment on file \"%s\" at line %d.\n\nDiff context:\n%s", c.FilePath, c.Line, c.DiffHunk)
+	}
+
+	return fmt.Sprintf("%s\n\n%s", commentContext, body)
+}
+
+func commit(repo git.Repo, branch string, commitMessage string) error {
+	status, err := repo.Status()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("git status output: %s", status)
+	if len(status) == 0 {
+		return nil
+	}
+
+	log.Printf("branch dirty, pushing changes")
+
+	if err := repo.Add("."); err != nil {
+		return fmt.Errorf("adding: %w", err)
+	}
+	if err := repo.Commit(commitMessage); err != nil {
+		return fmt.Errorf("committing changes: %w", err)
+	}
+	if err := repo.Push("origin", branch); err != nil {
+		return fmt.Errorf("pushing: %w", err)
+	}
+	return nil
+}
+
+func comment(ctx context.Context, ghClient githubapi.Client, c Comment, prInfo GitHubPR, replyText string) error {
+	log.Printf("creating comment to PR %d", prInfo.Number)
+	var err error
+	isReviewComment := c.IsReviewComment()
+	if isReviewComment {
+		log.Printf("creating review reply to comment %d", c.ID)
+		err = ghClient.CreateReviewCommentReply(ctx, prInfo.Owner, prInfo.Repo, prInfo.Number, c.ID, replyText)
+	} else {
+		err = ghClient.CreateComment(ctx, prInfo.Owner, prInfo.Repo, prInfo.Number, replyText)
+	}
+	if err != nil {
+		log.Printf("failed to create comment: %v", err)
+		return err
+	}
+	log.Printf("comment created successfully")
+	return nil
+}
+
+func react(ctx context.Context, ghClient githubapi.Client, c Comment, prInfo GitHubPR) error {
+	isReviewComment := c.IsReviewComment()
+	log.Printf("adding eyes reaction to comment %d (review: %v)", c.ID, isReviewComment)
+	if isReviewComment {
+		if err := ghClient.CreatePullRequestCommentReaction(ctx, prInfo.Owner, prInfo.Repo, c.ID, "eyes"); err != nil {
+			log.Printf("failed to add PR comment reaction: %v", err)
+			return err
+		}
+	} else {
+		if err := ghClient.CreateReaction(ctx, prInfo.Owner, prInfo.Repo, c.ID, "eyes"); err != nil {
+			log.Printf("failed to add reaction: %v", err)
+			return err
+		}
+	}
+	log.Printf("reaction added successfully")
+	return nil
+}
+
+func promptJob(ctx context.Context, client opencode.Client, sessionID string, taskText string, systemPrompt string, repoPath string, config OpenCodeConfig) (string, error) {
+	var parts []opencode.SessionPromptParamsPartUnion
+	parts = append(parts, opencode.TextPartInputParam{
+		Type: opencode.F(opencode.TextPartInputType("text")),
+		Text: opencode.String(taskText),
+	})
+
+	rsp, err := client.Session.Prompt(
+		ctx,
+		sessionID,
+		opencode.SessionPromptParams{
+			Directory: opencode.String(repoPath),
+			Model: opencode.F(opencode.SessionPromptParamsModel{
+				ProviderID: opencode.String(config.Provider),
+				ModelID:    opencode.String(config.Model),
+			}),
+			System: opencode.String(systemPrompt),
+			Parts:  opencode.F(parts),
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("prompting job: %w", err)
+	}
+
+	replyText := textFromRsp(rsp)
+	if replyText == "" {
+		return "", fmt.Errorf("parsing response")
+	}
+
+	return replyText, nil
+}
+
+func textFromRsp(rsp *opencode.SessionPromptResponse) string {
+	var textParts []string
+	for _, part := range rsp.Parts {
+		if part.Type == opencode.PartTypeText && part.Text != "" {
+			textParts = append(textParts, part.Text)
+		}
+	}
+	return strings.Join(textParts, "\n")
+}
+
+func filterActionableComments(comments []Comment, user string) []Comment {
+	var actionable []Comment
+	for _, c := range comments {
+		if c.Author != user {
+			continue
+		}
+		if !strings.Contains(c.Body, "@"+user) {
+			continue
+		}
+
+		if hasEyesReaction(c.Reactions, user) {
+			continue
+		}
+
+		actionable = append(actionable, c)
+	}
+	return actionable
+}
+
+func hasEyesReaction(reactions []Reaction, user string) bool {
+	for _, r := range reactions {
+		if strings.ToUpper(r.Content) == "EYES" && r.User == user {
+			return true
+		}
+	}
+	return false
+}
+
+func buildPRSystemPrompt(prDetails PRDetails) string {
+	return fmt.Sprintf(`Instructions:
+- You are helping with a GitHub pull request
+- Read each comment and execute the requested task
+- Commit changes with clear, concise messages
+- Reply to comments with your changes and include session metadata
+- Use bash to make changes, then commit and push
+
+PR Details:
+- PR #%d: %s
+- Author: %s
+- Base: %s <- Head: %s
+%s- Changes: +%d/-%d
+
+Changed Files:
+%s
+
+Previous Comments:
+%s`,
+		prDetails.Number, prDetails.Title,
+		prDetails.Author,
+		prDetails.BaseBranch, prDetails.HeadBranch,
+		descriptionLine(prDetails.Body),
+		prDetails.Additions, prDetails.Deletions,
+		fileList(prDetails.Files),
+		commentList(prDetails.Comments),
+	)
+}
+
+func descriptionLine(body string) string {
+	if body == "" {
+		return ""
+	}
+	return fmt.Sprintf("- Description: %s\n", body)
+}
+
+func fileList(files []PRFile) string {
+	if len(files) == 0 {
+		return ""
+	}
+	var lines []string
+	for _, f := range files {
+		lines = append(lines, fmt.Sprintf("- %s (%s) +%d/-%d", f.Path, f.ChangeType, f.Additions, f.Deletions))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func commentList(comments []Comment) string {
+	var lines []string
+	for _, c := range comments {
+		var location string
+		if c.IsReviewComment() {
+			location = fmt.Sprintf(" (%s:%d)", c.FilePath, c.Line)
+		}
+		lines = append(lines, fmt.Sprintf("- %s at %s%s: %s", c.Author, c.CreatedAt, location, c.Body))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/serve/handle_agent_dispatch.go
+++ b/internal/serve/handle_agent_dispatch.go
@@ -94,11 +94,11 @@ func handlerAgentDispatch(queue queuelib.Queue[agentDispatchJob], ghClient githu
 			enqueued++
 		}
 
-		status := "accepted"
 		if enqueued == 0 {
-			status = "no_actionable"
+			encode(w, http.StatusBadRequest, map[string]string{"error": "no actionable comments found"})
+			return
 		}
-		encode(w, http.StatusAccepted, response{SessionID: sessionID, Comments: actionable, RepoPath: repo.Path(), Status: status})
+		encode(w, http.StatusAccepted, response{SessionID: sessionID, Comments: actionable, RepoPath: repo.Path(), Status: "accepted"})
 	})
 }
 

--- a/internal/serve/handle_agent_dispatch.go
+++ b/internal/serve/handle_agent_dispatch.go
@@ -90,6 +90,7 @@ func handlerAgentDispatch(queue queuelib.Queue[agentDispatchJob], ghClient githu
 				log.Printf("failed to enqueue comment %d: %v", c.ID, err)
 				continue
 			}
+			log.Printf("enqueued job for comment %d on PR %s/%s/%d", c.ID, prInfo.Owner, prInfo.Repo, prInfo.Number)
 			enqueued++
 		}
 

--- a/internal/serve/handle_agent_dispatch.go
+++ b/internal/serve/handle_agent_dispatch.go
@@ -129,13 +129,12 @@ func runAgentDispatchJob(ctx context.Context, ghClient githubapi.Client, opencod
 
 	systemPrompt := buildPRSystemPrompt(prDetails)
 
-	promptText := prompt(c)
-	replyText, err := promptJob(ctx, opencodeClient, sessionID, promptText, systemPrompt, repoPath, config)
+	replyText, err := chat(ctx, opencodeClient, sessionID, prompt(c), systemPrompt, repoPath, config)
 	if err != nil {
 		return fmt.Errorf("prompting job: %w", err)
 	}
 
-	commitMsg, err := promptJob(ctx,
+	commitMsg, err := chat(ctx,
 		opencodeClient,
 		sessionID,
 		fmt.Sprintf("Summarize the following in less than 40 characters for the purposes of a commit message:\n\n%s", replyText),
@@ -214,9 +213,7 @@ func commit(repo git.Repo, branch string, commitMessage string) error {
 func comment(ctx context.Context, ghClient githubapi.Client, c Comment, prInfo GitHubPR, replyText string) error {
 	log.Printf("creating comment to PR %d", prInfo.Number)
 	var err error
-	isReviewComment := c.IsReviewComment()
-	if isReviewComment {
-		log.Printf("creating review reply to comment %d", c.ID)
+	if c.IsReviewComment() {
 		err = ghClient.CreateReviewCommentReply(ctx, prInfo.Owner, prInfo.Repo, prInfo.Number, c.ID, replyText)
 	} else {
 		err = ghClient.CreateComment(ctx, prInfo.Owner, prInfo.Repo, prInfo.Number, replyText)
@@ -247,7 +244,7 @@ func react(ctx context.Context, ghClient githubapi.Client, c Comment, prInfo Git
 	return nil
 }
 
-func promptJob(ctx context.Context, client opencode.Client, sessionID string, taskText string, systemPrompt string, repoPath string, config OpenCodeConfig) (string, error) {
+func chat(ctx context.Context, client opencode.Client, sessionID string, taskText string, systemPrompt string, repoPath string, config OpenCodeConfig) (string, error) {
 	var parts []opencode.SessionPromptParamsPartUnion
 	parts = append(parts, opencode.TextPartInputParam{
 		Type: opencode.F(opencode.TextPartInputType("text")),
@@ -271,22 +268,18 @@ func promptJob(ctx context.Context, client opencode.Client, sessionID string, ta
 		return "", fmt.Errorf("prompting job: %w", err)
 	}
 
-	replyText := textFromRsp(rsp)
-	if replyText == "" {
-		return "", fmt.Errorf("parsing response")
-	}
-
-	return replyText, nil
-}
-
-func textFromRsp(rsp *opencode.SessionPromptResponse) string {
 	var textParts []string
 	for _, part := range rsp.Parts {
 		if part.Type == opencode.PartTypeText && part.Text != "" {
 			textParts = append(textParts, part.Text)
 		}
 	}
-	return strings.Join(textParts, "\n")
+	replyText := strings.Join(textParts, "\n")
+	if replyText == "" {
+		return "", fmt.Errorf("parsing response")
+	}
+
+	return replyText, nil
 }
 
 func filterActionableComments(comments []Comment, user string) []Comment {

--- a/internal/serve/handle_agent_dispatch.go
+++ b/internal/serve/handle_agent_dispatch.go
@@ -124,6 +124,11 @@ func runAgentDispatchJob(ctx context.Context, ghClient githubapi.Client, opencod
 		c         = job.comment
 	)
 
+	repo := git.Open(repoPath)
+	if err := repo.SyncFromRemote(branch); err != nil {
+		return fmt.Errorf("syncing: %w", err)
+	}
+
 	if err := react(ctx, ghClient, c, prInfo); err != nil {
 		return fmt.Errorf("reacting: %w", err)
 	}
@@ -135,25 +140,28 @@ func runAgentDispatchJob(ctx context.Context, ghClient githubapi.Client, opencod
 		return fmt.Errorf("prompting job: %w", err)
 	}
 
-	commitMsg, err := chat(ctx,
-		opencodeClient,
-		sessionID,
-		fmt.Sprintf("Summarize the following in less than 40 characters for the purposes of a commit message:\n\n%s", replyText),
-		systemPrompt,
-		repoPath,
-		config,
-	)
+	status, err := repo.Status()
 	if err != nil {
-		commitMsg = "auto"
+		return fmt.Errorf("getting status: %w", err)
 	}
 
-	repo := git.Open(repoPath)
-	if err := commit(repo, branch, commitMsg); err != nil {
-		return fmt.Errorf("committing: %w", err)
-	}
+	log.Printf("branch dirty, pushing changes:\n%s", status)
+	if len(status) > 0 {
+		commitMsg, err := chat(ctx,
+			opencodeClient,
+			sessionID,
+			fmt.Sprintf("Summarize the following in less than 40 characters for the purposes of a commit message:\n\n%s", replyText),
+			systemPrompt,
+			repoPath,
+			config,
+		)
+		if err != nil {
+			commitMsg = "auto"
+		}
 
-	if err := repo.SyncToRemote(branch); err != nil {
-		return fmt.Errorf("syncing: %w", err)
+		if err := commit(repo, branch, commitMsg); err != nil {
+			return fmt.Errorf("committing: %w", err)
+		}
 	}
 
 	var commentURL string
@@ -187,16 +195,6 @@ func prompt(c Comment) string {
 }
 
 func commit(repo git.Repo, branch string, commitMessage string) error {
-	status, err := repo.Status()
-	if err != nil {
-		return err
-	}
-
-	log.Printf("git status output: %s", status)
-	if len(status) == 0 {
-		return nil
-	}
-
 	log.Printf("branch dirty, pushing changes")
 
 	if err := repo.Add("."); err != nil {

--- a/internal/serve/handlers.go
+++ b/internal/serve/handlers.go
@@ -9,11 +9,23 @@ import (
 
 func handleHealth(config OpenCodeConfig) http.Handler {
 	type response struct {
-		Status       string `json:"status"`
-		OpenCodeLive bool   `json:"opencodeLive"`
+		Status         string `json:"status"`
+		OpenCodeLive   bool   `json:"opencodeLive"`
+		OpenCodeURL    string `json:"opencodeUrl"`
+		OpenCodeStatus string `json:"opencodeStatus"`
+	}
+	running := IsOpenCodeRunning(config.Host, config.Port)
+	status := "stopped"
+	if running {
+		status = "running"
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		encode(w, http.StatusOK, response{Status: "ok", OpenCodeLive: IsOpenCodeRunning(config.Host, config.Port)})
+		encode(w, http.StatusOK, response{
+			Status:         "ok",
+			OpenCodeLive:   running,
+			OpenCodeURL:    "http://" + config.Host + ":" + config.Port,
+			OpenCodeStatus: status,
+		})
 	})
 }
 

--- a/internal/serve/handlers.go
+++ b/internal/serve/handlers.go
@@ -1,13 +1,10 @@
 package serve
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 
-	"github.com/thomasgormley/dev-cli-go/internal/git"
 	"github.com/thomasgormley/dev-cli-go/internal/githubapi"
-	"github.com/thomasgormley/dev-cli-go/internal/queuelib"
 )
 
 func handleHealth(config OpenCodeConfig) http.Handler {
@@ -20,95 +17,7 @@ func handleHealth(config OpenCodeConfig) http.Handler {
 	})
 }
 
-func handlerAgentDispatch(queue queuelib.Queue[agentDispatchJob], ghClient *githubapi.Client, user string, opencodeConfig OpenCodeConfig) http.Handler {
-	type request struct {
-		URL string `json:"url"`
-	}
-	type response struct {
-		SessionID string    `json:"sessionId"`
-		Comments  []Comment `json:"comments"`
-		RepoPath  string    `json:"repoPath"`
-		Status    string    `json:"status"`
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			encode(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-			return
-		}
-
-		req, err := decode[request](r)
-		if err != nil {
-			encode(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
-			return
-		}
-
-		if req.URL == "" {
-			encode(w, http.StatusBadRequest, map[string]string{"error": "url is required"})
-			return
-		}
-
-		prInfo, err := parseGitHubPRURL(req.URL)
-		if err != nil {
-			encode(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-			return
-		}
-
-		log.Printf("PR: owner=%s repo=%s number=%d", prInfo.Owner, prInfo.Repo, prInfo.Number)
-
-		prDetails, err := fetchPRDetails(r.Context(), ghClient, prInfo)
-		if err != nil {
-			log.Printf("fetchPRDetails failed: %v", err)
-			encode(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-			return
-		}
-
-		if prDetails.Author != user {
-			encode(w, http.StatusForbidden, map[string]string{"error": "PR author is not authorized"})
-			return
-		}
-
-		actionable := filterActionableComments(prDetails.Comments, user)
-
-		branch := prDetails.HeadBranch
-		repo, err := git.EnsureClone(r.Context(), prInfo.Owner, prInfo.Repo, branch)
-		if err != nil {
-			encode(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-			return
-		}
-
-		sessionID, err := createOpencodeSession(r.Context(), repo.Path(), opencodeConfig)
-		if err != nil {
-			encode(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to create session: %v", err)})
-			return
-		}
-
-		enqueued := 0
-		for _, c := range actionable {
-			job := agentDispatchJob{
-				prInfo:     prInfo,
-				prDetails:  prDetails,
-				headBranch: prDetails.HeadBranch,
-				comment:    c,
-				repoPath:   repo.Path(),
-				sessionID:  sessionID,
-				user:       user,
-			}
-			if err := queue.Enqueue(r.Context(), job); err != nil {
-				log.Printf("failed to enqueue comment %d: %v", c.ID, err)
-				continue
-			}
-			enqueued++
-		}
-
-		status := "accepted"
-		if enqueued == 0 {
-			status = "no_actionable"
-		}
-		encode(w, http.StatusAccepted, response{SessionID: sessionID, Comments: actionable, RepoPath: repo.Path(), Status: status})
-	})
-}
-
-func handlerDebug(ghClient *githubapi.Client) http.Handler {
+func handlerDebug(ghClient githubapi.Client) http.Handler {
 	type request struct {
 		URL string `json:"url"`
 	}

--- a/internal/serve/opencode.go
+++ b/internal/serve/opencode.go
@@ -7,11 +7,9 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/sst/opencode-sdk-go"
-	"github.com/sst/opencode-sdk-go/option"
 )
 
 func IsOpenCodeRunning(host, port string) bool {
@@ -61,14 +59,14 @@ func StartOpenCode(ctx context.Context, config OpenCodeConfig, timeout time.Dura
 
 	cmd := exec.CommandContext(ctx, "opencode", "serve", "--hostname", config.Host, "--port", config.Port)
 	if err := cmd.Start(); err != nil {
-		return false, func() {}, fmt.Errorf("failed to start OpenCode: %w", err)
+		return false, func() {}, fmt.Errorf("starting OpenCode: %w", err)
 	}
 
 	log.Printf("waiting for OpenCode to be ready at %s...", baseURL)
 	if err := waitForOpenCode(config, timeout); err != nil {
 		cmd.Process.Signal(os.Interrupt)
 		cmd.Wait()
-		return false, func() {}, fmt.Errorf("OpenCode failed to start: %w", err)
+		return false, func() {}, fmt.Errorf("starting OpenCode: %w", err)
 	}
 
 	log.Printf("OpenCode is ready")
@@ -81,99 +79,14 @@ func StartOpenCode(ctx context.Context, config OpenCodeConfig, timeout time.Dura
 	return true, closer, nil
 }
 
-func createOpencodeSession(ctx context.Context, repoPath string, config OpenCodeConfig) (string, error) {
-	openCodeURL := fmt.Sprintf("http://%s:%s", config.Host, config.Port)
-	client := opencode.NewClient(option.WithBaseURL(openCodeURL))
+func createOpencodeSession(ctx context.Context, client opencode.Client, repoPath string, config OpenCodeConfig) (string, error) {
 
 	session, err := client.Session.New(ctx, opencode.SessionNewParams{
 		Directory: opencode.String(repoPath),
 	})
 	if err != nil {
-		return "", fmt.Errorf("create session: %w", err)
+		return "", fmt.Errorf("creating session: %w", err)
 	}
 
 	return session.ID, nil
-}
-
-func textFromRsp(rsp *opencode.SessionPromptResponse) string {
-	var textParts []string
-	for _, part := range rsp.Parts {
-		if part.Type == opencode.PartTypeText && part.Text != "" {
-			textParts = append(textParts, part.Text)
-		}
-	}
-	return strings.Join(textParts, "\n")
-}
-
-func buildPRSystemPrompt(prInfo GitHubPR, prDetails PRDetails) string {
-	var parts []string
-
-	parts = append(parts, "Instructions:")
-	parts = append(parts, "- You are helping with a GitHub pull request")
-	parts = append(parts, "- Read each comment and execute the requested task")
-	parts = append(parts, "- Commit changes with clear, concise messages")
-	parts = append(parts, "- Reply to comments with your changes and include session metadata")
-	parts = append(parts, "- Use bash to make changes, then commit and push")
-	parts = append(parts, "")
-
-	parts = append(parts, "PR Details:")
-	parts = append(parts, fmt.Sprintf("- PR #%d: %s", prDetails.Number, prDetails.Title))
-	parts = append(parts, fmt.Sprintf("- Author: %s", prDetails.Author))
-	parts = append(parts, fmt.Sprintf("- Base: %s <- Head: %s", prDetails.BaseBranch, prDetails.HeadBranch))
-	if prDetails.Body != "" {
-		parts = append(parts, fmt.Sprintf("- Description: %s", prDetails.Body))
-	}
-	parts = append(parts, fmt.Sprintf("- Changes: +%d/-%d", prDetails.Additions, prDetails.Deletions))
-	parts = append(parts, "")
-
-	if len(prDetails.Files) > 0 {
-		parts = append(parts, "Changed Files:")
-		for _, f := range prDetails.Files {
-			parts = append(parts, fmt.Sprintf("- %s (%s) +%d/-%d", f.Path, f.ChangeType, f.Additions, f.Deletions))
-		}
-		parts = append(parts, "")
-	}
-
-	parts = append(parts, "Previous Comments:")
-	for _, c := range prDetails.Comments {
-		var location string
-		if c.IsReviewComment() {
-			location = fmt.Sprintf(" (%s:%d)", c.FilePath, c.Line)
-		}
-		parts = append(parts, fmt.Sprintf("- %s at %s%s: %s", c.Author, c.CreatedAt, location, c.Body))
-	}
-
-	return strings.Join(parts, "\n")
-}
-
-func promptJob(ctx context.Context, client *opencode.Client, sessionID string, taskText string, systemPrompt string, repoPath string, config OpenCodeConfig) (string, error) {
-	var parts []opencode.SessionPromptParamsPartUnion
-	parts = append(parts, opencode.TextPartInputParam{
-		Type: opencode.F(opencode.TextPartInputType("text")),
-		Text: opencode.String(taskText),
-	})
-
-	rsp, err := client.Session.Prompt(
-		ctx,
-		sessionID,
-		opencode.SessionPromptParams{
-			Directory: opencode.String(repoPath),
-			Model: opencode.F(opencode.SessionPromptParamsModel{
-				ProviderID: opencode.String(config.Provider),
-				ModelID:    opencode.String(config.Model),
-			}),
-			System: opencode.String(systemPrompt),
-			Parts:  opencode.F(parts),
-		},
-	)
-	if err != nil {
-		return "", fmt.Errorf("failed to prompt job: %w", err)
-	}
-
-	replyText := textFromRsp(rsp)
-	if replyText == "" {
-		return "", fmt.Errorf("failed to parse response")
-	}
-
-	return replyText, nil
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -9,20 +9,17 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
-	"strings"
 
 	"github.com/sst/opencode-sdk-go"
-	"github.com/sst/opencode-sdk-go/option"
-
-	"github.com/thomasgormley/dev-cli-go/internal/git"
 	"github.com/thomasgormley/dev-cli-go/internal/githubapi"
 	"github.com/thomasgormley/dev-cli-go/internal/queuelib"
 )
 
 type HandleOpts struct {
 	GitHubUser     string
-	GitHubClient   *githubapi.Client
+	GitHubClient   githubapi.Client
 	AllowedOrigins []string
+	OpenCodeClient opencode.Client
 	OpenCode       OpenCodeConfig
 }
 
@@ -45,14 +42,20 @@ type agentDispatchJob struct {
 
 func Handle(ctx context.Context, opt HandleOpts) http.Handler {
 
-	q := queuelib.New[agentDispatchJob]()
+	queue := queuelib.New[agentDispatchJob]()
 	mux := http.NewServeMux()
 	mux.Handle("/api/health", handleHealth(opt.OpenCode))
 	mux.Handle("/api/debug", handlerDebug(opt.GitHubClient))
 	mux.Handle(
 		"/api/agent/dispatch",
 		opencodeCheckMiddleware(opt.OpenCode,
-			handlerAgentDispatch(q, opt.GitHubClient, opt.GitHubUser, opt.OpenCode),
+			handlerAgentDispatch(
+				queue,
+				opt.GitHubClient,
+				opt.OpenCodeClient,
+				opt.GitHubUser,
+				opt.OpenCode,
+			),
 		),
 	)
 
@@ -60,77 +63,9 @@ func Handle(ctx context.Context, opt HandleOpts) http.Handler {
 	handler = corsMiddleware(handler, opt.AllowedOrigins)
 	handler = loggingMiddleware(handler)
 
-	go func() {
-		for {
-			job, ok := q.Dequeue(ctx)
-			if !ok {
-				return
-			}
-			if err := handleAgentDispatchJob(ctx, opt.GitHubClient, opt.OpenCode, job); err != nil {
-				log.Printf("job failed for comment %d: %v", job.comment.ID, err)
-			}
-		}
-	}()
+	go processAgentDispatchQueue(ctx, queue, opt.GitHubClient, opt.OpenCodeClient, opt.OpenCode)
 
 	return handler
-}
-
-func handleAgentDispatchJob(ctx context.Context, ghClient *githubapi.Client, config OpenCodeConfig, job agentDispatchJob) error {
-	prInfo := job.prInfo
-	prDetails := job.prDetails
-	c := job.comment
-	repoPath := job.repoPath
-	sessionID := job.sessionID
-	branch := job.headBranch
-
-	if err := react(ctx, ghClient, c, prInfo); err != nil {
-		return fmt.Errorf("reaction failed: %w", err)
-	}
-
-	opencodeClient := opencode.NewClient(option.WithBaseURL(fmt.Sprintf("http://%s:%s", config.Host, config.Port)))
-
-	systemPrompt := buildPRSystemPrompt(prInfo, prDetails)
-
-	promptText := prompt(c)
-	replyText, err := promptJob(ctx, opencodeClient, sessionID, promptText, systemPrompt, repoPath, config)
-	if err != nil {
-		return fmt.Errorf("prompt job failed: %w", err)
-	}
-
-	commitMsg, err := promptJob(ctx,
-		opencodeClient,
-		sessionID,
-		fmt.Sprintf("Summarize the following in less than 40 characters for the purposes of a commit message:\n\n%s", replyText),
-		systemPrompt,
-		repoPath,
-		config,
-	)
-	if err != nil {
-		commitMsg = "auto"
-	}
-
-	repo := git.Open(repoPath)
-	if err := commit(repo, branch, commitMsg); err != nil {
-		return fmt.Errorf("commit failed: %w", err)
-	}
-
-	if err := repo.SyncToRemote(branch); err != nil {
-		return fmt.Errorf("sync failed: %w", err)
-	}
-
-	var commentURL string
-	if c.IsReviewComment() {
-		commentURL = fmt.Sprintf("https://github.com/%s/%s/pull/%d#discussion_r%d", prInfo.Owner, prInfo.Repo, prInfo.Number, c.ID)
-	} else {
-		commentURL = fmt.Sprintf("https://github.com/%s/%s/pull/%d#issuecomment-%d", prInfo.Owner, prInfo.Repo, prInfo.Number, c.ID)
-	}
-	metadata := fmt.Sprintf("<details><summary>👉 info</summary>\n\n| Key | Value |\n|-----|-------|\n| In reply to | [#%d](%s) |\n| Session | `%s` |\n\n</details>", c.ID, commentURL, sessionID)
-	if err := comment(ctx, ghClient, c, prInfo, replyText+"\n\n"+metadata); err != nil {
-		return fmt.Errorf("comment failed: %w", err)
-	}
-
-	log.Printf("comment %d processed successfully", c.ID)
-	return nil
 }
 
 func corsMiddleware(h http.Handler, allowedOrigins []string) http.Handler {
@@ -243,7 +178,7 @@ func encode[T any](w http.ResponseWriter, status int, v T) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
-		return fmt.Errorf("encode json: %w", err)
+		return fmt.Errorf("encoding json: %w", err)
 	}
 	return nil
 }
@@ -251,7 +186,7 @@ func encode[T any](w http.ResponseWriter, status int, v T) error {
 func decode[T any](r *http.Request) (T, error) {
 	var v T
 	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
-		return v, fmt.Errorf("decode json: %w", err)
+		return v, fmt.Errorf("decoding json: %w", err)
 	}
 	return v, nil
 }
@@ -293,7 +228,7 @@ func convertReactions(reactions []struct {
 	return r
 }
 
-func fetchPRDetails(ctx context.Context, ghClient *githubapi.Client, prInfo GitHubPR) (PRDetails, error) {
+func fetchPRDetails(ctx context.Context, ghClient githubapi.Client, prInfo GitHubPR) (PRDetails, error) {
 	data, err := ghClient.GetPRDetails(ctx, prInfo.Owner, prInfo.Repo, prInfo.Number)
 	if err != nil {
 		return PRDetails{}, err
@@ -348,108 +283,4 @@ func fetchPRDetails(ctx context.Context, ghClient *githubapi.Client, prInfo GitH
 		Comments:   comments,
 		Files:      files,
 	}, nil
-}
-
-func filterActionableComments(comments []Comment, user string) []Comment {
-	var actionable []Comment
-	for _, c := range comments {
-		if c.Author != user {
-			continue
-		}
-		if !strings.Contains(c.Body, "@"+user) {
-			continue
-		}
-
-		if hasEyesReaction(c.Reactions, user) {
-			continue
-		}
-
-		actionable = append(actionable, c)
-	}
-	return actionable
-}
-
-func hasEyesReaction(reactions []Reaction, user string) bool {
-	for _, r := range reactions {
-		if strings.ToUpper(r.Content) == "EYES" && r.User == user {
-			return true
-		}
-	}
-	return false
-}
-
-func react(ctx context.Context, ghClient *githubapi.Client, c Comment, prInfo GitHubPR) error {
-	isReviewComment := c.IsReviewComment()
-	log.Printf("adding eyes reaction to comment %d (review: %v)", c.ID, isReviewComment)
-	if isReviewComment {
-		if err := ghClient.CreatePullRequestCommentReaction(ctx, prInfo.Owner, prInfo.Repo, c.ID, "eyes"); err != nil {
-			log.Printf("failed to add PR comment reaction: %v", err)
-			return err
-		}
-	} else {
-		if err := ghClient.CreateReaction(ctx, prInfo.Owner, prInfo.Repo, c.ID, "eyes"); err != nil {
-			log.Printf("failed to add reaction: %v", err)
-			return err
-		}
-	}
-	log.Printf("reaction added successfully")
-	return nil
-}
-
-func prompt(c Comment) string {
-	body := strings.TrimSpace(strings.TrimPrefix(c.Body, "@"+c.Author))
-
-	if !c.IsReviewComment() {
-		return body
-	}
-
-	commentContext := fmt.Sprintf("You are reviewing a comment on file \"%s\" at line %d.", c.FilePath, c.Line)
-	if c.DiffHunk != "" {
-		commentContext = fmt.Sprintf("You are reviewing a comment on file \"%s\" at line %d.\n\nDiff context:\n%s", c.FilePath, c.Line, c.DiffHunk)
-	}
-
-	return fmt.Sprintf("%s\n\n%s", commentContext, body)
-}
-
-func commit(repo git.Repo, branch string, commitMessage string) error {
-	status, err := repo.Status()
-	if err != nil {
-		return err
-	}
-
-	log.Printf("git status output: %s", status)
-	if len(status) == 0 {
-		return nil
-	}
-
-	log.Printf("branch dirty, pushing changes")
-
-	if err := repo.Add("."); err != nil {
-		return fmt.Errorf("git add: %w", err)
-	}
-	if err := repo.Commit(commitMessage); err != nil {
-		return fmt.Errorf("git commit: %w", err)
-	}
-	if err := repo.Push("origin", branch); err != nil {
-		return fmt.Errorf("git push: %w", err)
-	}
-	return nil
-}
-
-func comment(ctx context.Context, ghClient *githubapi.Client, c Comment, prInfo GitHubPR, replyText string) error {
-	log.Printf("creating comment to PR %d", prInfo.Number)
-	var err error
-	isReviewComment := c.IsReviewComment()
-	if isReviewComment {
-		log.Printf("creating review reply to comment %d", c.ID)
-		err = ghClient.CreateReviewCommentReply(ctx, prInfo.Owner, prInfo.Repo, prInfo.Number, c.ID, replyText)
-	} else {
-		err = ghClient.CreateComment(ctx, prInfo.Owner, prInfo.Repo, prInfo.Number, replyText)
-	}
-	if err != nil {
-		log.Printf("failed to create comment: %v", err)
-		return err
-	}
-	log.Printf("comment created successfully")
-	return nil
 }


### PR DESCRIPTION
Refactor agent dispatch handler and improve error handling

This PR extracts the agent dispatch HTTP handler into its own file (internal/serve/handle_agent_dispatch.go), introduces a common serveBeforeFunc for server connectivity checks, and improves error responses. Key changes include: extracted dispatch handler logic from handlers.go, added server-running check as a reusable BeforeFunc applied to the agent subcommand, changed GetHealth to return value type instead of pointer, added logging for enqueued jobs, and changed response to HTTP 400 when no actionable comments are found.